### PR TITLE
追加読み込み（ページング）の追加

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'kotlin-kapt'
 apply plugin: 'dagger.hilt.android.plugin'
 
 android {
-    compileSdk 30
+    compileSdk 31
 
     sourceSets {
         main.kotlin.srcDirs += 'src/main/kotlin'
@@ -13,7 +13,7 @@ android {
     defaultConfig {
         applicationId "jp.one_system_group.diary_sample_android"
         minSdk 23
-        targetSdk 30
+        targetSdk 31
         versionCode 1
         versionName "1.0"
 
@@ -75,6 +75,8 @@ dependencies {
     // hilt
     implementation"com.google.dagger:hilt-android:$hilt_version"
     kapt "com.google.dagger:hilt-android-compiler:$hilt_version"
+    // paging
+    implementation "androidx.paging:paging-compose:1.0.0-alpha13"
 
     // Debug
     debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
@@ -83,6 +85,7 @@ dependencies {
     testImplementation "junit:junit:4.13.2"
     testImplementation"com.google.dagger:hilt-android:$hilt_version"
     kaptTest"com.google.dagger:hilt-android:$hilt_version"
+    testImplementation "androidx.paging:paging-common:$paging_version"
 
     // Instrumented-Unit-Tests
     androidTestImplementation "androidx.test.ext:junit:1.1.3"

--- a/app/src/main/kotlin/jp/one_system_group/diary_sample_android/MainActivity.kt
+++ b/app/src/main/kotlin/jp/one_system_group/diary_sample_android/MainActivity.kt
@@ -9,12 +9,14 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.lifecycle.Observer
+import androidx.paging.PagingData
 import dagger.hilt.android.AndroidEntryPoint
 import jp.one_system_group.diary_sample_android.model.DiaryRow
 import jp.one_system_group.diary_sample_android.ui.home.HomeScreen
 import jp.one_system_group.diary_sample_android.ui.theme.DiarySampleAndroidTheme
 import jp.one_system_group.diary_sample_android.viewmodel.DiaryListViewModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -23,16 +25,11 @@ class MainActivity : ComponentActivity() {
     @ExperimentalMaterialApi
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        viewModel.getDiaryList().observe(this, {
-            // APIから取得した結果を画面に反映する
-            drawScreen(it)
-        })
-        // 初期表示
-        drawScreen(emptyList())
+        drawScreen(viewModel.diaryList)
     }
 
     @ExperimentalMaterialApi
-    private fun drawScreen(list: List<DiaryRow>) {
+    private fun drawScreen(list: Flow<PagingData<DiaryRow>>) {
         setContent {
             DiarySampleAndroidTheme {
                 Surface(color = MaterialTheme.colors.background) {
@@ -49,9 +46,12 @@ class MainActivity : ComponentActivity() {
 fun DefaultPreview() {
     // Jetpack Composeで表示する用のメソッド
     DiarySampleAndroidTheme {
-        val diaryList = (15 downTo 1).map {
-            DiaryRow(it, "投稿${it}", "2021/01/01")
-        }
+        // 残念ながらページ読み込み付きのリストプレビューは表示されない
+        val diaryList = flowOf(
+            PagingData.from((15 downTo 1).map {
+                DiaryRow(it, "投稿${it}", "2021/01/01")
+            })
+        )
         HomeScreen(diaryList)
     }
 }

--- a/app/src/main/kotlin/jp/one_system_group/diary_sample_android/repository/DiaryPagingSource.kt
+++ b/app/src/main/kotlin/jp/one_system_group/diary_sample_android/repository/DiaryPagingSource.kt
@@ -1,0 +1,42 @@
+package jp.one_system_group.diary_sample_android.repository
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import jp.one_system_group.diary_sample_android.model.DiaryRow
+
+class DiaryPagingSource(
+    private val diaryRepository: DiaryRepository
+) : PagingSource<Int, DiaryRow>() {
+
+    override suspend fun load(
+        params: LoadParams<Int>,
+    ): LoadResult<Int, DiaryRow> {
+        return try {
+            // Start refresh at page 1 if undefined.
+            val nextPage = params.key ?: 1
+            val response = diaryRepository.getDiaryList(nextPage).body()
+            LoadResult.Page(
+                data = response!!,
+                // 前ページは無し
+                prevKey = null,
+                // nextKeyがnullの場合、次ページが存在しない
+                nextKey = if (response.isEmpty()) null else nextPage.plus(1),
+            )
+        } catch (e: Exception) {
+            // Handle errors in this block and return LoadResult.Error if it is an
+            // expected error (such as a network failure).
+            LoadResult.Error(e)
+        }
+    }
+
+    // The refresh key is used for subsequent refresh calls to PagingSource.load after the initial load
+    override fun getRefreshKey(state: PagingState<Int, DiaryRow>): Int? {
+        // We need to get the previous key (or next key if previous is null) of the page
+        // that was closest to the most recently accessed index.
+        // Anchor position is the most recently accessed index
+        return state.anchorPosition?.let { anchorPosition ->
+            state.closestPageToPosition(anchorPosition)?.prevKey?.plus(1)
+                ?: state.closestPageToPosition(anchorPosition)?.nextKey?.minus(1)
+        }
+    }
+}

--- a/app/src/main/kotlin/jp/one_system_group/diary_sample_android/repository/DiaryRepository.kt
+++ b/app/src/main/kotlin/jp/one_system_group/diary_sample_android/repository/DiaryRepository.kt
@@ -3,17 +3,21 @@ package jp.one_system_group.diary_sample_android.repository
 import jp.one_system_group.diary_sample_android.api.WebService
 import jp.one_system_group.diary_sample_android.model.DiaryRow
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import retrofit2.Response
 import javax.inject.Inject
 
 interface DiaryRepository {
-    suspend fun getDiaryList(): Response<List<DiaryRow>>
+    suspend fun getDiaryList(page: Int): Response<List<DiaryRow>>
 }
 
 class DiaryRepositoryImpl @Inject constructor(
     private val webService: WebService
 ) : DiaryRepository {
-    override suspend fun getDiaryList(): Response<List<DiaryRow>> =
-        withContext(Dispatchers.IO) { webService.requestDiaryList(1) }
+    override suspend fun getDiaryList(page: Int): Response<List<DiaryRow>> =
+        withContext(Dispatchers.IO) {
+            delay(3000)
+            webService.requestDiaryList(page)
+        }
 }

--- a/app/src/main/kotlin/jp/one_system_group/diary_sample_android/ui/home/DiaryList.kt
+++ b/app/src/main/kotlin/jp/one_system_group/diary_sample_android/ui/home/DiaryList.kt
@@ -1,26 +1,114 @@
 package jp.one_system_group.diary_sample_android.ui.home
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.material.Divider
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.ListItem
-import androidx.compose.material.Text
+import androidx.compose.material.*
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.paging.LoadState
+import androidx.paging.PagingData
+import androidx.paging.compose.collectAsLazyPagingItems
+import androidx.paging.compose.items
 import jp.one_system_group.diary_sample_android.model.DiaryRow
+import kotlinx.coroutines.flow.Flow
 
 @ExperimentalMaterialApi
 @Composable
-fun DiaryList(diaryList: List<DiaryRow>) {
+fun DiaryList(diaryList: Flow<PagingData<DiaryRow>>) {
+    val lazyDiaryItems = diaryList.collectAsLazyPagingItems()
     LazyColumn {
-        itemsIndexed(diaryList) { _, item ->
-            ListItem(
-                modifier = Modifier.clickable(onClick = {}),
-                text = { Text(item.title) },
-                secondaryText = { Text(item.postDate) })
-            Divider()
+        items(lazyDiaryItems) { item ->
+            if (item != null) {
+                ListItem(
+                    modifier = Modifier.clickable(onClick = {
+                        // リストアイテムクリック時の処理
+                    }),
+                    text = { Text(item.title) },
+                    secondaryText = { Text(item.postDate) })
+                Divider()
+            }
+        }
+        lazyDiaryItems.apply {
+            when {
+                // 初回読み込み
+                loadState.refresh is LoadState.Loading -> {
+                    item { LoadingView(modifier = Modifier.fillParentMaxSize()) }
+                }
+                // 追加読み込み
+                loadState.append is LoadState.Loading -> {
+                    item { LoadingItem() }
+                }
+                // 初回読み込み時エラー
+                loadState.refresh is LoadState.Error -> {
+                    val e = lazyDiaryItems.loadState.refresh as LoadState.Error
+                    item {
+                        ErrorItem(
+                            message = e.error.localizedMessage!!,
+                            modifier = Modifier.fillParentMaxSize(),
+                            onClickRetry = { retry() }
+                        )
+                    }
+                }
+                // 追加読み込み時エラー
+                loadState.append is LoadState.Error -> {
+                    val e = lazyDiaryItems.loadState.append as LoadState.Error
+                    item {
+                        ErrorItem(
+                            message = e.error.localizedMessage!!,
+                            onClickRetry = { retry() }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun LoadingView(
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        CircularProgressIndicator()
+    }
+}
+
+@Composable
+fun LoadingItem() {
+    CircularProgressIndicator(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp)
+            .wrapContentWidth(Alignment.CenterHorizontally)
+    )
+}
+
+@Composable
+fun ErrorItem(
+    message: String,
+    modifier: Modifier = Modifier,
+    onClickRetry: () -> Unit
+) {
+    Row(
+        modifier = modifier.padding(16.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = message,
+            maxLines = 1,
+            modifier = Modifier.weight(1f),
+            style = MaterialTheme.typography.h6,
+        )
+        OutlinedButton(onClick = onClickRetry) {
+            Text(text = "Try again")
         }
     }
 }

--- a/app/src/main/kotlin/jp/one_system_group/diary_sample_android/ui/home/HomeScreen.kt
+++ b/app/src/main/kotlin/jp/one_system_group/diary_sample_android/ui/home/HomeScreen.kt
@@ -4,12 +4,14 @@ import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.runtime.Composable
+import androidx.paging.PagingData
 import jp.one_system_group.diary_sample_android.model.DiaryRow
+import kotlinx.coroutines.flow.Flow
 
 @ExperimentalMaterialApi
 @Composable
 fun HomeScreen(
-    diaryList: List<DiaryRow>
+    diaryList: Flow<PagingData<DiaryRow>>
 ) {
     Scaffold(
         topBar = {

--- a/app/src/main/kotlin/jp/one_system_group/diary_sample_android/viewmodel/DiaryListViewModel.kt
+++ b/app/src/main/kotlin/jp/one_system_group/diary_sample_android/viewmodel/DiaryListViewModel.kt
@@ -1,13 +1,14 @@
 package jp.one_system_group.diary_sample_android.viewmodel
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
 import dagger.hilt.android.lifecycle.HiltViewModel
 import jp.one_system_group.diary_sample_android.model.DiaryRow
+import jp.one_system_group.diary_sample_android.repository.DiaryPagingSource
 import jp.one_system_group.diary_sample_android.repository.DiaryRepository
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 @HiltViewModel
@@ -15,19 +16,11 @@ class DiaryListViewModel @Inject constructor(
     private val diaryRepository: DiaryRepository
 ) : ViewModel() {
 
-    private val diaryList = MutableLiveData<List<DiaryRow>>()
-
-    fun getDiaryList(): LiveData<List<DiaryRow>> {
-        if (diaryList.value == null) {
-            loadDiaryList()
-        }
-        return diaryList
-    }
-
-    private fun loadDiaryList() {
-        // 非同期で日記の情報を読み込み、MutableLiveData に反映する
-        viewModelScope.launch {
-            diaryList.postValue(diaryRepository.getDiaryList().body())
-        }
-    }
+    val diaryList : Flow<PagingData<DiaryRow>> = Pager(
+        // Configure how data is loaded by passing additional properties to
+        // PagingConfig, such as prefetchDistance.
+        PagingConfig(pageSize = 10, maxSize = 1000)
+    ) {
+        DiaryPagingSource(diaryRepository)
+    }.flow
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,18 +1,19 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext {
-        kotlin_version = '1.5.21'
-        compose_version = '1.0.1'
+        kotlin_version = '1.5.30'
+        compose_version = '1.0.3'
         lifecycle_version = '2.3.1'
         retrofit_version = '2.9.0'
         hilt_version = '2.38.1'
+        paging_version = '3.0.1'
     }
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:7.0.1"
+        classpath "com.android.tools.build:gradle:7.0.2"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.google.dagger:hilt-android-gradle-plugin:$hilt_version"
     }


### PR DESCRIPTION
# 変更内容
日記一覧の追加読み込みを追加しました。
初期アクセス時に10件読み込み、下にスクロールするたびに10件づつ追加読み込みするようにしています。
![Animation1](https://user-images.githubusercontent.com/15532048/135739595-ec868ae4-4f2a-4a39-bfa2-c7d539fe8f8d.gif)

読み込み時にローディングアニメーションを使用するようにしていますが、
APIの応答が早すぎて一瞬で消えてしまうため、あえてAPIリクエストする際に3秒ディレイを入れて読み込まれているのを分かりやすくしてます。

---
### 本プルリクで対応していないこと
- 一覧を読み込んだ（全ページ取得）後にサーバ側の日記の数に変更があった場合に更新されません（一番最後まで読み込んだ後に追加でAPIリクエストしない）
- 通信エラーのケース（通信エラーの場合は空リストを表示するのでなく、前回取得した日記一覧を表示してもよさそう。アプリ内にも日記を保存する）