### PR TITLE
オフライン時はデータベースから日記を表示するように修正

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -77,6 +77,10 @@ dependencies {
     kapt "com.google.dagger:hilt-android-compiler:$hilt_version"
     // paging
     implementation "androidx.paging:paging-compose:1.0.0-alpha13"
+    // room
+    implementation "androidx.room:room-runtime:$room_version"
+    annotationProcessor "androidx.room:room-compiler:$room_version"
+    kapt "androidx.room:room-compiler:$room_version"
 
     // Debug
     debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
@@ -98,3 +102,4 @@ dependencies {
 kapt {
     correctErrorTypes true
 }
+

--- a/app/src/main/kotlin/jp/one_system_group/diary_sample_android/database/AppDatabase.kt
+++ b/app/src/main/kotlin/jp/one_system_group/diary_sample_android/database/AppDatabase.kt
@@ -1,0 +1,9 @@
+package jp.one_system_group.diary_sample_android.database
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+
+@Database(entities = [DiaryEntity::class], version = 1)
+abstract class AppDatabase : RoomDatabase() {
+    abstract fun diaryDao(): DiaryDao
+}

--- a/app/src/main/kotlin/jp/one_system_group/diary_sample_android/database/DiaryDao.kt
+++ b/app/src/main/kotlin/jp/one_system_group/diary_sample_android/database/DiaryDao.kt
@@ -1,0 +1,17 @@
+package jp.one_system_group.diary_sample_android.database
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+
+@Dao
+interface DiaryDao {
+    @Query("SELECT * FROM diary WHERE page = :page ORDER BY post_date DESC, id DESC")
+    fun findByPage(page: Int): List<DiaryEntity>
+
+    @Insert
+    fun insert(vararg diary: DiaryEntity)
+
+    @Query("DELETE FROM diary WHERE page = :page")
+    fun deleteByPage(page: Int)
+}

--- a/app/src/main/kotlin/jp/one_system_group/diary_sample_android/database/DiaryEntity.kt
+++ b/app/src/main/kotlin/jp/one_system_group/diary_sample_android/database/DiaryEntity.kt
@@ -1,0 +1,27 @@
+package jp.one_system_group.diary_sample_android.database
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import jp.one_system_group.diary_sample_android.model.DiaryRow
+
+@Entity(tableName = "diary")
+data class DiaryEntity(
+    @PrimaryKey
+    @ColumnInfo(name = "id")
+    val id: Int,
+    @ColumnInfo(name = "title")
+    val title: String,
+    @ColumnInfo(name = "post_date")
+    val postDate: String,
+    @ColumnInfo(name = "page")
+    val page: Int
+) {
+    fun toDiaryRow(): DiaryRow {
+        return DiaryRow(
+            id = id,
+            title = title,
+            postDate = postDate
+        )
+    }
+}

--- a/app/src/main/kotlin/jp/one_system_group/diary_sample_android/database/di/DatabaseModule.kt
+++ b/app/src/main/kotlin/jp/one_system_group/diary_sample_android/database/di/DatabaseModule.kt
@@ -1,0 +1,25 @@
+package jp.one_system_group.diary_sample_android.database.di
+
+import android.content.Context
+import androidx.room.Room
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import jp.one_system_group.diary_sample_android.database.AppDatabase
+import javax.inject.Singleton
+
+@InstallIn(SingletonComponent::class)
+@Module
+class DatabaseModule {
+    @Provides
+    @Singleton
+    fun provideDatabase(
+        @ApplicationContext context: Context
+    ) = Room.databaseBuilder(context, AppDatabase::class.java, "DiarySample.db").build()
+
+    @Singleton
+    @Provides
+    fun provideDao(db: AppDatabase) = db.diaryDao()
+}

--- a/app/src/main/kotlin/jp/one_system_group/diary_sample_android/model/DiaryRow.kt
+++ b/app/src/main/kotlin/jp/one_system_group/diary_sample_android/model/DiaryRow.kt
@@ -1,7 +1,18 @@
 package jp.one_system_group.diary_sample_android.model
 
+import jp.one_system_group.diary_sample_android.database.DiaryEntity
+
 data class DiaryRow(
     val id: Int,
     val title: String,
     val postDate: String,
-)
+) {
+    fun toDiaryEntity(page: Int): DiaryEntity {
+        return DiaryEntity(
+            id = id,
+            title = title,
+            postDate = postDate,
+            page = page
+        )
+    }
+}

--- a/app/src/main/kotlin/jp/one_system_group/diary_sample_android/repository/DiaryRepository.kt
+++ b/app/src/main/kotlin/jp/one_system_group/diary_sample_android/repository/DiaryRepository.kt
@@ -1,6 +1,7 @@
 package jp.one_system_group.diary_sample_android.repository
 
 import jp.one_system_group.diary_sample_android.api.WebService
+import jp.one_system_group.diary_sample_android.database.DiaryDao
 import jp.one_system_group.diary_sample_android.model.DiaryRow
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -9,15 +10,36 @@ import retrofit2.Response
 import javax.inject.Inject
 
 interface DiaryRepository {
-    suspend fun getDiaryList(page: Int): Response<List<DiaryRow>>
+    suspend fun getDiaryListFromWeb(page: Int): Response<List<DiaryRow>>
+    suspend fun getDiaryListFromDb(page: Int): List<DiaryRow>
 }
 
 class DiaryRepositoryImpl @Inject constructor(
-    private val webService: WebService
+    private val webService: WebService,
+    private val dao: DiaryDao
 ) : DiaryRepository {
-    override suspend fun getDiaryList(page: Int): Response<List<DiaryRow>> =
+    override suspend fun getDiaryListFromWeb(page: Int): Response<List<DiaryRow>> =
         withContext(Dispatchers.IO) {
             delay(3000)
-            webService.requestDiaryList(page)
+            val response = webService.requestDiaryList(page)
+            val diaryList = response.body()
+            if (diaryList != null) {
+                // DBに保存する
+                dao.deleteByPage(page)
+                diaryList.forEach {
+                    dao.insert(
+                        it.toDiaryEntity(page)
+                    )
+                }
+            }
+            response
         }
+
+    override suspend fun getDiaryListFromDb(page: Int): List<DiaryRow> {
+        return withContext(Dispatchers.IO) {
+            delay(3000)
+            val diaries = dao.findByPage(page = page)
+            diaries.map { it.toDiaryRow() }
+        }
+    }
 }

--- a/app/src/main/kotlin/jp/one_system_group/diary_sample_android/repository/di/RepositoryModule.kt
+++ b/app/src/main/kotlin/jp/one_system_group/diary_sample_android/repository/di/RepositoryModule.kt
@@ -5,6 +5,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import jp.one_system_group.diary_sample_android.api.WebService
+import jp.one_system_group.diary_sample_android.database.DiaryDao
 import jp.one_system_group.diary_sample_android.repository.DiaryRepository
 import jp.one_system_group.diary_sample_android.repository.DiaryRepositoryImpl
 import javax.inject.Singleton
@@ -15,8 +16,9 @@ class RepositoryModule {
     @Provides
     @Singleton
     fun provideDiaryRepository(
-        webService: WebService
+        webService: WebService,
+        dao : DiaryDao
     ): DiaryRepository {
-        return DiaryRepositoryImpl(webService)
+        return DiaryRepositoryImpl(webService, dao)
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
         retrofit_version = '2.9.0'
         hilt_version = '2.38.1'
         paging_version = '3.0.1'
+        room_version = "2.3.0"
     }
     repositories {
         google()


### PR DESCRIPTION
# 変更内容
アプリにローカルデータベース（[SQLite](https://www.sqlite.org/index.html)）を持たせ、APIからデータが取得できない場合は前回取得しデータベースに保存された情報を画面に表示するように修正

# 詳細内容
- APIアクセス成功時に取得したページのデータをDBに登録する処理を追加
- APIからデータが取得できない場合は、DBに保存した内容を画面に表示する処理を追加
- ORMは[Room](https://developer.android.com/training/data-storage/room?hl=ja)を使用するように修正