### PR TITLE
メニューの追加

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,6 +81,10 @@ dependencies {
     implementation "androidx.room:room-runtime:$room_version"
     annotationProcessor "androidx.room:room-compiler:$room_version"
     kapt "androidx.room:room-compiler:$room_version"
+    // Navigation
+    implementation "androidx.navigation:navigation-compose:2.4.0-alpha10"
+    // material-icon
+    implementation "androidx.compose.material:material-icons-extended:$compose_version"
 
     // Debug
     debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"

--- a/app/src/main/kotlin/jp/one_system_group/diary_sample_android/ui/home/HomeScreen.kt
+++ b/app/src/main/kotlin/jp/one_system_group/diary_sample_android/ui/home/HomeScreen.kt
@@ -4,23 +4,42 @@ import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.navigation.compose.rememberNavController
 import androidx.paging.PagingData
 import jp.one_system_group.diary_sample_android.model.DiaryRow
+import jp.one_system_group.diary_sample_android.ui.menu.DrawerScreen
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
 
 @ExperimentalMaterialApi
 @Composable
 fun HomeScreen(
     diaryList: Flow<PagingData<DiaryRow>>
 ) {
+    val scaffoldState = rememberScaffoldState(rememberDrawerState(DrawerValue.Closed))
+    val scope = rememberCoroutineScope()
+    val navController = rememberNavController()
+    val drawerState = rememberDrawerState(DrawerValue.Closed)
     Scaffold(
+        scaffoldState = scaffoldState,
         topBar = {
             TopAppBar(
                 title = {
                     Text(text = "日記")
                 },
                 navigationIcon = {
-                    IconButton(onClick = { /* doSomething() */ }) {
+                    IconButton(onClick = {
+                        scope.launch {
+                            scaffoldState.drawerState.open()
+                        }
+                    }) {
                         Icon(Icons.Filled.Menu, contentDescription = null)
                     }
                 },
@@ -28,8 +47,28 @@ fun HomeScreen(
         },
         content = {
             DiaryList(diaryList)
+        },
+        drawerContent = {
+            ModalDrawer(
+                drawerContent = {
+                },
+                content = {
+                    DrawerScreen(
+                        scaffoldState = scaffoldState,
+                        scope = scope,
+                        navController = navController
+                    )
+                }
+            )
+        },
+        drawerShape = object : Shape {
+            override fun createOutline(
+                size: Size,
+                layoutDirection: LayoutDirection,
+                density: Density
+            ): Outline {
+                return Outline.Rectangle(Rect(left = 0f, top = 0f, right = 750f, bottom = 2000f))
+            }
         }
     )
 }
-
-

--- a/app/src/main/kotlin/jp/one_system_group/diary_sample_android/ui/menu/DrawerItem.kt
+++ b/app/src/main/kotlin/jp/one_system_group/diary_sample_android/ui/menu/DrawerItem.kt
@@ -1,0 +1,52 @@
+package jp.one_system_group.diary_sample_android.ui.menu
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+
+@Composable
+fun DrawerItem(item: DrawerListItem, selected: Boolean, onItemClick: (DrawerListItem) -> Unit) {
+    val background =
+        if (selected) MaterialTheme.colors.primary.copy(alpha = 0.12f) else Color.Transparent
+    val textColor = if (selected) MaterialTheme.colors.primary else MaterialTheme.colors.onSurface
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(64.dp)
+            .clickable(onClick = { onItemClick(item) })
+            .background(background)
+    ) {
+        Spacer(modifier = Modifier.size(24.dp))
+        Icon(item.icon, contentDescription = item.route, tint = textColor)
+        Spacer(modifier = Modifier.size(32.dp))
+        Text(
+            text = item.title,
+            fontSize = 18.sp,
+            style = MaterialTheme.typography.subtitle1,
+            color = textColor,
+            maxLines = 1
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun DrawerItemPreview() {
+    Column() {
+    DrawerItem(item = DrawerListItem.Favorite, selected = false, onItemClick = {})
+    DrawerItem(item = DrawerListItem.Bookmark, selected = false, onItemClick = {})
+    DrawerItem(item = DrawerListItem.Setting, selected = true, onItemClick = {})
+    }
+}

--- a/app/src/main/kotlin/jp/one_system_group/diary_sample_android/ui/menu/DrawerScreen.kt
+++ b/app/src/main/kotlin/jp/one_system_group/diary_sample_android/ui/menu/DrawerScreen.kt
@@ -80,10 +80,8 @@ fun DrawerScreen(
             modifier = Modifier
                 .height(1.dp)
         )
-        var currentRoute = items[2].route
         items.forEach { item ->
-            DrawerItem(item = item, selected = currentRoute == item.route, onItemClick = {
-                currentRoute = item.route
+            DrawerItem(item = item, selected = false, onItemClick = {
                 // Close drawer
                 scope.launch {
                     scaffoldState.drawerState.close()

--- a/app/src/main/kotlin/jp/one_system_group/diary_sample_android/ui/menu/DrawerScreen.kt
+++ b/app/src/main/kotlin/jp/one_system_group/diary_sample_android/ui/menu/DrawerScreen.kt
@@ -1,0 +1,103 @@
+package jp.one_system_group.diary_sample_android.ui.menu
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Bookmark
+import androidx.compose.material.icons.rounded.Favorite
+import androidx.compose.material.icons.rounded.Settings
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import jp.one_system_group.diary_sample_android.R
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+sealed class DrawerListItem(val route: String, val title: String, val icon: ImageVector) {
+    object Favorite : DrawerListItem("Favorite", "お気に入り", Icons.Rounded.Favorite)
+    object Bookmark : DrawerListItem("Bookmark", "ブックマーク", Icons.Rounded.Bookmark)
+    object Setting : DrawerListItem("Setting", "設定", Icons.Rounded.Settings)
+}
+
+@Composable
+fun DrawerScreen(
+    scope: CoroutineScope,
+    scaffoldState: ScaffoldState,
+    navController: NavController
+) {
+    val items = listOf(
+        DrawerListItem.Favorite,
+        DrawerListItem.Bookmark,
+        DrawerListItem.Setting
+    )
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(colorResource(id = R.color.design_default_color_on_primary))
+
+    ) {
+        Spacer(
+            modifier = Modifier
+                .height(50.dp)
+                .width(1000.dp)
+        )
+        Image(
+            painter = painterResource(R.drawable.ic_launcher_foreground),
+            contentDescription = "Contact profile picture",
+            modifier = Modifier
+                .size(50.dp)
+                .height(50.dp)
+                .offset(x = 30.dp)
+                .clip(CircleShape)
+                .background(Color.DarkGray)
+        )
+        // Header
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(100.dp)
+                .background(Color.White)
+                .padding(16.dp), content = {
+                Text("test@example.jp", fontSize = 22.sp, fontWeight = FontWeight.Bold)
+                Text("20XX/01/01", color = Color.DarkGray)
+            }, verticalArrangement = Arrangement.Bottom
+        )
+        Divider(
+            modifier = Modifier
+                .height(1.dp)
+        )
+        var currentRoute = items[2].route
+        items.forEach { item ->
+            DrawerItem(item = item, selected = currentRoute == item.route, onItemClick = {
+                currentRoute = item.route
+                // Close drawer
+                scope.launch {
+                    scaffoldState.drawerState.close()
+                }
+            })
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun DrawerPreview() {
+    val scope = rememberCoroutineScope()
+    val scaffoldState = rememberScaffoldState(rememberDrawerState(DrawerValue.Closed))
+    val navController = rememberNavController()
+    DrawerScreen(scope = scope, scaffoldState = scaffoldState, navController = navController)
+}


### PR DESCRIPTION
# 内容
アプリのメニューを追加しました。
![スクリーンショット 2021-11-28 161321](https://user-images.githubusercontent.com/15532048/143733323-4f1358c4-01f3-4013-abef-28900ddee66f.png)

各メニュー、アカウントなど、どうするかはまだ設計していないので、見た目の部分だけです。

# 詳細
- [Material Icon](https://developer.android.com/reference/kotlin/androidx/compose/material/icons/Icons)をライブラリに追加しました。
- 各メニューを選択した際に将来的に画面遷移をすることになりそうなので、使ってはいないですが[Navigation](https://developer.android.com/jetpack/androidx/releases/navigation?hl=ja)もライブラリに追加してます。
