### PR TITLE
Webサービス・ページングの単体テスト

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -91,6 +91,10 @@ dependencies {
 
     // Local-Unit-Tests
     testImplementation "junit:junit:4.13.2"
+    testImplementation 'org.assertj:assertj-core:3.21.0'
+    testImplementation "org.mockito.kotlin:mockito-kotlin:4.0.0"
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.5.0"
+    testImplementation "com.squareup.okhttp3:mockwebserver3:5.0.0-alpha.3"
     testImplementation"com.google.dagger:hilt-android:$hilt_version"
     kaptTest"com.google.dagger:hilt-android:$hilt_version"
     testImplementation "androidx.paging:paging-common:$paging_version"

--- a/app/src/test/kotlin/jp/one_system_group/diary_sample_android/mock/MockDiaryRepository.kt
+++ b/app/src/test/kotlin/jp/one_system_group/diary_sample_android/mock/MockDiaryRepository.kt
@@ -1,0 +1,44 @@
+package jp.one_system_group.diary_sample_android.mock
+
+import jp.one_system_group.diary_sample_android.api.WebService
+import jp.one_system_group.diary_sample_android.database.DiaryDao
+import jp.one_system_group.diary_sample_android.repository.DiaryRepository
+import jp.one_system_group.diary_sample_android.repository.DiaryRepositoryImpl
+import mockwebserver3.Dispatcher
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import mockwebserver3.RecordedRequest
+import okhttp3.OkHttpClient
+import org.mockito.Mockito
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+class MockDiaryRepository {
+    private var mockWebServer = MockWebServer()
+    private var mockDiaryRepository: DiaryRepository
+
+    init {
+        mockWebServer.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse {
+                return MockResponse().setBody("[{\"id\":\"1\",\"title\":\"テスト\",\"postDate\":\"2022/01/01\"}]")
+                    .setResponseCode(200)
+            }
+        }
+        val retrofit = Retrofit.Builder()
+            .baseUrl(mockWebServer.url(""))
+            .client(OkHttpClient())
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+        val webService = retrofit.create(WebService::class.java)
+        mockWebServer.start()
+        mockDiaryRepository = DiaryRepositoryImpl(webService, Mockito.mock(DiaryDao::class.java))
+    }
+
+    fun getMock(): DiaryRepository {
+        return mockDiaryRepository
+    }
+
+    fun close() {
+        mockWebServer.shutdown()
+    }
+}

--- a/app/src/test/kotlin/jp/one_system_group/diary_sample_android/repository/DiaryPagingSourceTest.kt
+++ b/app/src/test/kotlin/jp/one_system_group/diary_sample_android/repository/DiaryPagingSourceTest.kt
@@ -1,0 +1,48 @@
+package jp.one_system_group.diary_sample_android.repository
+
+import androidx.paging.PagingSource
+import jp.one_system_group.diary_sample_android.mock.MockDiaryRepository
+import jp.one_system_group.diary_sample_android.model.DiaryRow
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+
+class DiaryPagingSourceTest {
+    private lateinit var mockRepository: MockDiaryRepository
+
+    @Before
+    fun setUp() {
+        mockRepository = MockDiaryRepository()
+    }
+
+    @After
+    fun tearDown() {
+        mockRepository.close()
+    }
+
+    @Test
+    fun loadTest(): Unit = runBlocking {
+        val pagingSource = DiaryPagingSource(mockRepository.getMock())
+        val expectedPageKey = (1..5).toList() // 1～5ページまでテスト
+        expectedPageKey.forEach {
+            assertThat(
+                PagingSource.LoadResult.Page(
+                    data = listOf(DiaryRow(1, "テスト", "2022/01/01")),
+                    prevKey = null,
+                    nextKey = it + 1 // 次のページ番号が取得できること
+                )
+            ).isEqualTo(
+                pagingSource.load(
+                    PagingSource.LoadParams.Refresh(
+                        key = it, // 現在のページを指定して次ページを読み込み
+                        loadSize = 10,
+                        placeholdersEnabled = false
+                    )
+                )
+            )
+        }
+    }
+}

--- a/app/src/test/kotlin/jp/one_system_group/diary_sample_android/repository/DiaryRepositoryImplTest.kt
+++ b/app/src/test/kotlin/jp/one_system_group/diary_sample_android/repository/DiaryRepositoryImplTest.kt
@@ -1,0 +1,31 @@
+package jp.one_system_group.diary_sample_android.repository
+
+import jp.one_system_group.diary_sample_android.mock.MockDiaryRepository
+import jp.one_system_group.diary_sample_android.model.DiaryRow
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+
+class DiaryRepositoryImplTest {
+    private lateinit var mockRepository: MockDiaryRepository
+
+    @Before
+    fun setUp() {
+        mockRepository = MockDiaryRepository()
+    }
+
+    @After
+    fun tearDown() {
+        mockRepository.close()
+    }
+
+    @Test
+    fun getDiaryListFromWebTest(): Unit = runBlocking {
+        val response = mockRepository.getMock().getDiaryListFromWeb(1)
+        assertThat(response.isSuccessful).isTrue
+        assertThat(response.body()).isEqualTo(listOf(DiaryRow(1, "テスト", "2022/01/01")))
+    }
+}


### PR DESCRIPTION
# 内容
Webサービス連携部分とページングの単体テストを作成しました。

# 詳細
- テストライブラリに[Junit4](https://github.com/junit-team/junit4)（androidはjunit5に正式対応していない模様）、検証ライブラリに[AssertJ](https://joel-costigliola.github.io/assertj/)、モックライブラリに[Mocito-kotlin](https://site.mockito.org/)を使用。
- okhttpの[MockWebServer](https://github.com/square/okhttp/tree/master/mockwebserver)を使ってAPIを擬似的に呼び出しテストを実施。
- ページング（10件ロードしたら次ページが取得できる部分）をテスト。
- Webサービスのレスポンスがエラーだった場合のテストはDB参照のテストがでてくるため、未実装。

