### PR TITLE
日記参照時のオフライン対応

### DIFF
--- a/app/src/main/kotlin/jp/one_system_group/diary_sample_android/database/AppDatabase.kt
+++ b/app/src/main/kotlin/jp/one_system_group/diary_sample_android/database/AppDatabase.kt
@@ -3,7 +3,7 @@ package jp.one_system_group.diary_sample_android.database
 import androidx.room.Database
 import androidx.room.RoomDatabase
 
-@Database(entities = arrayOf(DiaryEntity::class, DiaryContentEntity::class), version = 2,  exportSchema = false)
+@Database(entities = arrayOf(DiaryEntity::class, DiaryContentEntity::class), version = 1,  exportSchema = false)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun diaryDao(): DiaryDao
     abstract fun diaryContentDao(): DiaryContentDao

--- a/app/src/main/kotlin/jp/one_system_group/diary_sample_android/database/AppDatabase.kt
+++ b/app/src/main/kotlin/jp/one_system_group/diary_sample_android/database/AppDatabase.kt
@@ -3,7 +3,8 @@ package jp.one_system_group.diary_sample_android.database
 import androidx.room.Database
 import androidx.room.RoomDatabase
 
-@Database(entities = [DiaryEntity::class], version = 1)
+@Database(entities = arrayOf(DiaryEntity::class, DiaryContentEntity::class), version = 2,  exportSchema = false)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun diaryDao(): DiaryDao
+    abstract fun diaryContentDao(): DiaryContentDao
 }

--- a/app/src/main/kotlin/jp/one_system_group/diary_sample_android/database/DiaryContentDao.kt
+++ b/app/src/main/kotlin/jp/one_system_group/diary_sample_android/database/DiaryContentDao.kt
@@ -1,0 +1,18 @@
+package jp.one_system_group.diary_sample_android.database
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+
+@Dao
+interface DiaryContentDao {
+
+    @Query("SELECT * FROM diaryContent WHERE id = :id")
+    fun findContentById(id: Int): DiaryContentEntity
+
+    @Insert
+    fun Insert(vararg content: DiaryContentEntity)
+
+    @Query("DELETE FROM diaryContent WHERE id = :id")
+    fun DeleteById(id: Int)
+}

--- a/app/src/main/kotlin/jp/one_system_group/diary_sample_android/database/DiaryContentEntity.kt
+++ b/app/src/main/kotlin/jp/one_system_group/diary_sample_android/database/DiaryContentEntity.kt
@@ -1,0 +1,25 @@
+package jp.one_system_group.diary_sample_android.database
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import jp.one_system_group.diary_sample_android.model.Diary
+
+@Entity(tableName = "diaryContent")
+data class DiaryContentEntity (
+    @PrimaryKey
+    @ColumnInfo(name = "id")
+    val id: Int,
+    @ColumnInfo(name = "title")
+    val title: String,
+    @ColumnInfo(name = "content")
+    val content: String
+) {
+    fun toDiary(): Diary {
+        return Diary(
+            id = id,
+            title = title,
+            content = content
+        )
+    }
+}

--- a/app/src/main/kotlin/jp/one_system_group/diary_sample_android/database/di/DatabaseModule.kt
+++ b/app/src/main/kotlin/jp/one_system_group/diary_sample_android/database/di/DatabaseModule.kt
@@ -19,18 +19,7 @@ class DatabaseModule {
     @Singleton
     fun provideDatabase(
         @ApplicationContext context: Context
-    ) = Room.databaseBuilder(context, AppDatabase::class.java, "DiarySample.db")
-        .addMigrations(object: Migration(1, 2){
-            override fun migrate(database: SupportSQLiteDatabase) {
-                database.execSQL(
-                "CREATE TABLE diaryContent (" +
-                        " id INTEGER PRIMARY KEY NOT NULL, " +
-                        " title TEXT NOT NULL, " +
-                        " content TEXT NOT NULL" +
-                        ");")
-            }
-        })
-        .build()
+    ) = Room.databaseBuilder(context, AppDatabase::class.java, "DiarySample.db").build()
 
     @Singleton
     @Provides

--- a/app/src/main/kotlin/jp/one_system_group/diary_sample_android/database/di/DatabaseModule.kt
+++ b/app/src/main/kotlin/jp/one_system_group/diary_sample_android/database/di/DatabaseModule.kt
@@ -2,6 +2,8 @@ package jp.one_system_group.diary_sample_android.database.di
 
 import android.content.Context
 import androidx.room.Room
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -17,9 +19,24 @@ class DatabaseModule {
     @Singleton
     fun provideDatabase(
         @ApplicationContext context: Context
-    ) = Room.databaseBuilder(context, AppDatabase::class.java, "DiarySample.db").build()
+    ) = Room.databaseBuilder(context, AppDatabase::class.java, "DiarySample.db")
+        .addMigrations(object: Migration(1, 2){
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                "CREATE TABLE diaryContent (" +
+                        " id INTEGER PRIMARY KEY NOT NULL, " +
+                        " title TEXT NOT NULL, " +
+                        " content TEXT NOT NULL" +
+                        ");")
+            }
+        })
+        .build()
 
     @Singleton
     @Provides
     fun provideDao(db: AppDatabase) = db.diaryDao()
+
+    @Singleton
+    @Provides
+    fun provideDaoContent(db: AppDatabase) = db.diaryContentDao()
 }

--- a/app/src/main/kotlin/jp/one_system_group/diary_sample_android/model/Diary.kt
+++ b/app/src/main/kotlin/jp/one_system_group/diary_sample_android/model/Diary.kt
@@ -1,6 +1,7 @@
 package jp.one_system_group.diary_sample_android.model
 
 data class Diary(
+    val id: Int,
     val title: String,
     val content: String
 )

--- a/app/src/main/kotlin/jp/one_system_group/diary_sample_android/repository/DiaryRepository.kt
+++ b/app/src/main/kotlin/jp/one_system_group/diary_sample_android/repository/DiaryRepository.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import retrofit2.Response
+import java.lang.Exception
 import javax.inject.Inject
 
 interface DiaryRepository {
@@ -67,10 +68,14 @@ class DiaryRepositoryImpl @Inject constructor(
         }
 
         // APIから取得できなかったららDBから取得する
-        var diary = Diary(-1,"", "")
+        var diary = Diary(-1,"エラー", "日記が見つかりませんでした")
         runBlocking {
             withContext(Dispatchers.IO) {
-                diary = daoContent.findContentById(id).toDiary()
+                // 例外が発生しても日記の表示処理を続ける
+                try {
+                    diary = daoContent.findContentById(id).toDiary()
+                } catch (e: Exception) {
+                }
             }
         }
         return diary

--- a/app/src/main/kotlin/jp/one_system_group/diary_sample_android/repository/DiaryRepository.kt
+++ b/app/src/main/kotlin/jp/one_system_group/diary_sample_android/repository/DiaryRepository.kt
@@ -1,14 +1,14 @@
 package jp.one_system_group.diary_sample_android.repository
 
 import jp.one_system_group.diary_sample_android.api.WebService
+import jp.one_system_group.diary_sample_android.database.DiaryContentDao
+import jp.one_system_group.diary_sample_android.database.DiaryContentEntity
 import jp.one_system_group.diary_sample_android.database.DiaryDao
 import jp.one_system_group.diary_sample_android.model.Diary
 import jp.one_system_group.diary_sample_android.model.DiaryRow
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.withContext
 import retrofit2.Response
 import javax.inject.Inject
 
@@ -20,7 +20,8 @@ interface DiaryRepository {
 
 class DiaryRepositoryImpl @Inject constructor(
     private val webService: WebService,
-    private val dao: DiaryDao
+    private val dao: DiaryDao,
+    private val daoContent: DiaryContentDao
 ) : DiaryRepository {
     override suspend fun getDiaryListFromWeb(page: Int): Response<List<DiaryRow>> =
         withContext(Dispatchers.IO) {
@@ -56,9 +57,22 @@ class DiaryRepositoryImpl @Inject constructor(
     private suspend fun getDiarySuspend(id : Int) : Diary {
         val response = webService.getDiary(id)
         if (response.isSuccessful) {
+            // APIから取得したデータをDBに保存しておく
+            withContext(Dispatchers.IO) {
+                val entity = DiaryContentEntity(requireNotNull(response.body()).id, requireNotNull(response.body()).title, requireNotNull(response.body()).content)
+                daoContent.DeleteById(id)
+                daoContent.Insert(entity)
+            }
             return requireNotNull(response.body())
         }
-        throw Exception()
-//        throw NetworkException(response.code(), response.errorBody().toString())
+
+        // APIから取得できなかったららDBから取得する
+        var diary = Diary(-1,"", "")
+        runBlocking {
+            withContext(Dispatchers.IO) {
+                diary = daoContent.findContentById(id).toDiary()
+            }
+        }
+        return diary
     }
 }

--- a/app/src/main/kotlin/jp/one_system_group/diary_sample_android/repository/di/RepositoryModule.kt
+++ b/app/src/main/kotlin/jp/one_system_group/diary_sample_android/repository/di/RepositoryModule.kt
@@ -5,7 +5,9 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import jp.one_system_group.diary_sample_android.api.WebService
+import jp.one_system_group.diary_sample_android.database.DiaryContentDao
 import jp.one_system_group.diary_sample_android.database.DiaryDao
+import jp.one_system_group.diary_sample_android.database.di.DatabaseModule_ProvideDaoContentFactory
 import jp.one_system_group.diary_sample_android.repository.DiaryRepository
 import jp.one_system_group.diary_sample_android.repository.DiaryRepositoryImpl
 import javax.inject.Singleton
@@ -17,8 +19,9 @@ class RepositoryModule {
     @Singleton
     fun provideDiaryRepository(
         webService: WebService,
-        dao : DiaryDao
+        dao : DiaryDao,
+        daoContent : DiaryContentDao
     ): DiaryRepository {
-        return DiaryRepositoryImpl(webService, dao)
+        return DiaryRepositoryImpl(webService, dao, daoContent)
     }
 }

--- a/app/src/main/kotlin/jp/one_system_group/diary_sample_android/viewmodel/DiaryViewModel.kt
+++ b/app/src/main/kotlin/jp/one_system_group/diary_sample_android/viewmodel/DiaryViewModel.kt
@@ -13,7 +13,7 @@ import javax.inject.Inject
 class DiaryViewModel @Inject constructor(
     private val repository: DiaryRepository,
 ): ViewModel() {
-    var diary : Diary = Diary("","")
+    var diary : Diary = Diary(-1,"", "")
 
     fun getDiary(id : Int) {
         viewModelScope.launch {


### PR DESCRIPTION
日記参照時のオフライン対応化をしてみました。
一覧のオフライン対応と同じく、APIから個別の日記を取得した際にDBに保存しておき、
APIから取得できなかった場合は、DBに保存してあった日記を取得して表示するというものです。

ROOMのDB変更が、プログラム内で明示的にバージョンを上げたり、
テーブル定義を書かないといけないようで、
DatabaseModule辺りは、やや妙な実装になっていると思います。