### PR TITLE
認証画面から認証APIを呼び出して認証を行う

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -80,7 +80,12 @@ dependencies {
     implementation "androidx.activity:activity-compose:1.4.0"
     // retrofit2
     implementation "com.squareup.retrofit2:retrofit:$retrofit_version"
+
+    // OkHttp
+    implementation("com.squareup.okhttp3:okhttp:4.10.0")
+    implementation("com.squareup.okhttp3:logging-interceptor:4.10.0")
     implementation "com.squareup.retrofit2:converter-gson:$retrofit_version"
+
     // Gson
     implementation 'com.google.code.gson:gson:2.9.0'
     // hilt

--- a/app/src/main/kotlin/jp/one_system_group/diary_sample_android/MainActivity.kt
+++ b/app/src/main/kotlin/jp/one_system_group/diary_sample_android/MainActivity.kt
@@ -7,34 +7,55 @@ import androidx.activity.viewModels
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
+import androidx.compose.runtime.Composable
+import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
-import androidx.paging.PagingData
 import dagger.hilt.android.AndroidEntryPoint
-import jp.one_system_group.diary_sample_android.model.DiaryRow
 import jp.one_system_group.diary_sample_android.ui.home.HomeScreen
 import jp.one_system_group.diary_sample_android.ui.theme.DiarySampleAndroidTheme
+import jp.one_system_group.diary_sample_android.viewmodel.AuthViewModel
 import jp.one_system_group.diary_sample_android.viewmodel.DiaryListViewModel
-import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
-    private val viewModel: DiaryListViewModel by viewModels()
+    private val authViewModel: AuthViewModel by viewModels()
+    private val diaryListViewModel: DiaryListViewModel by viewModels()
 
     @OptIn(ExperimentalMaterialApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        drawScreen(viewModel.diaryList)
-    }
-
-    @ExperimentalMaterialApi
-    private fun drawScreen(list: Flow<PagingData<DiaryRow>>) {
         setContent {
             DiarySampleAndroidTheme {
                 val navController = rememberNavController()
                 Surface(color = MaterialTheme.colors.background) {
-                    HomeScreen(navController, list)
+                    HomeScreen(
+                        navController,
+                        // 認証処理
+                        login(navController),
+                        // 日記一覧画面の表示に必要なデータ
+                        diaryListViewModel.diaryList
+                    )
                 }
             }
         }
     }
+
+    @Composable
+    private fun login(navController: NavHostController): (String, String) -> Unit =
+        { email, password ->
+            // 認証処理を呼び出す
+            authViewModel.login(email, password)
+            CoroutineScope(Dispatchers.Main).launch {
+                // 認証結果を待つ
+                val result = authViewModel.resultFlow.firstOrNull { it != null }
+                if (result != null) {
+                    // 認証が完了したら、日記一覧画面へ遷移する
+                    navController.navigate("main")
+                }
+            }
+        }
 }

--- a/app/src/main/kotlin/jp/one_system_group/diary_sample_android/api/AuthorizationIntercepter.kt
+++ b/app/src/main/kotlin/jp/one_system_group/diary_sample_android/api/AuthorizationIntercepter.kt
@@ -1,0 +1,41 @@
+package jp.one_system_group.diary_sample_android.api
+
+import jp.one_system_group.diary_sample_android.infra.TokenManager
+import okhttp3.Interceptor
+import okhttp3.Request
+import okhttp3.Response
+import java.io.IOException
+
+
+class AuthorizationInterceptor(private val tokenManager: TokenManager) : Interceptor {
+    @Throws(IOException::class)
+    override fun intercept(chain: Interceptor.Chain): Response {
+        return try {
+            // トークンを取得
+            val token = tokenManager.getToken()
+            val request: Request = chain.request()
+
+            // トークンがなければ、何もしない
+            if (token.isNullOrEmpty()) return chain.proceed(request)
+
+            // ヘッダにHEADER_PLACEHOLDERがなければ、何もしない
+            if (request.header(HEADER_NAME) == null) return chain.proceed(request)
+            if (HEADER_VALUE != request.header(HEADER_NAME)) return chain.proceed(request)
+
+            // "Authorization"ヘッダをtokenに設定
+            val newRequest = request.newBuilder()
+                .header(HEADER_NAME, HEADER_VALUE_BEARER + token)
+                .build()
+            chain.proceed(newRequest)
+        } catch (e: Exception) {
+            chain.proceed(chain.request())
+        }
+    }
+
+    companion object {
+        private const val HEADER_NAME = "Authorization"
+        private const val HEADER_VALUE = "DUMMY"
+        private const val HEADER_VALUE_BEARER = "bearer"
+        const val HEADER_PLACEHOLDER = "$HEADER_NAME: $HEADER_VALUE"
+    }
+}

--- a/app/src/main/kotlin/jp/one_system_group/diary_sample_android/api/WebService.kt
+++ b/app/src/main/kotlin/jp/one_system_group/diary_sample_android/api/WebService.kt
@@ -1,16 +1,23 @@
 package jp.one_system_group.diary_sample_android.api
 
+import jp.one_system_group.diary_sample_android.model.Auth
 import jp.one_system_group.diary_sample_android.model.Diary
 import jp.one_system_group.diary_sample_android.model.DiaryRow
 import retrofit2.Response
-import retrofit2.http.GET
-import retrofit2.http.Path
+import retrofit2.http.*
 
 interface WebService {
+    // 認証
+    @POST("login")
+    suspend fun login(@Body auth: Auth): Response<String>
+
     // 日記の一覧を取得
     @GET("lists/{page}")
+    @Headers(AuthorizationInterceptor.HEADER_PLACEHOLDER)
     suspend fun requestDiaryList(@Path("page") page: Int): Response<List<DiaryRow>>
+
     // 日記の内容を取得
     @GET("diary/{id}")
-    suspend fun getDiary(@Path("id") id : Int): Response<Diary>
+    @Headers(AuthorizationInterceptor.HEADER_PLACEHOLDER)
+    suspend fun getDiary(@Path("id") id: Int): Response<Diary>
 }

--- a/app/src/main/kotlin/jp/one_system_group/diary_sample_android/api/di/WebServiceModule.kt
+++ b/app/src/main/kotlin/jp/one_system_group/diary_sample_android/api/di/WebServiceModule.kt
@@ -1,13 +1,18 @@
 package jp.one_system_group.diary_sample_android.api.di
 
+import android.content.Context
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import jp.one_system_group.diary_sample_android.api.AuthorizationInterceptor
 import jp.one_system_group.diary_sample_android.api.WebService
+import jp.one_system_group.diary_sample_android.infra.TokenManager
 import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import java.util.concurrent.TimeUnit
@@ -26,11 +31,21 @@ object WebServiceModule {
 
     @Singleton
     @Provides
-    fun provideHttpClient(): OkHttpClient =
+    fun provideHttpClient(
+        @ApplicationContext context: Context
+    ): OkHttpClient =
         OkHttpClient.Builder()
             .connectTimeout(90, TimeUnit.SECONDS)
             .readTimeout(90, TimeUnit.SECONDS)
             .writeTimeout(90, TimeUnit.SECONDS)
+            .addInterceptor(HttpLoggingInterceptor().apply {
+                level = HttpLoggingInterceptor.Level.BODY
+            })
+            .addInterceptor(AuthorizationInterceptor(
+                TokenManager(
+                    context,
+                )
+            ))
             .build()
 
     @Singleton

--- a/app/src/main/kotlin/jp/one_system_group/diary_sample_android/infra/TokenManager.kt
+++ b/app/src/main/kotlin/jp/one_system_group/diary_sample_android/infra/TokenManager.kt
@@ -1,0 +1,27 @@
+package jp.one_system_group.diary_sample_android.infra
+
+import android.content.Context
+import android.content.SharedPreferences
+
+class TokenManager(context: Context) {
+    private val sharedPreferences: SharedPreferences
+    private val editor: SharedPreferences.Editor
+
+    init {
+        sharedPreferences = context.getSharedPreferences(SHARED_PREF_NAME, Context.MODE_PRIVATE)
+        editor = sharedPreferences.edit()
+    }
+
+    fun saveToken(token: String) {
+        editor.putString(KEY_ACCESS_TOKEN, token).apply()
+    }
+
+    fun getToken(): String? {
+        return sharedPreferences.getString(KEY_ACCESS_TOKEN, null)
+    }
+
+    companion object {
+        private const val SHARED_PREF_NAME = "diary_sample_android"
+        private const val KEY_ACCESS_TOKEN = "access_token"
+    }
+}

--- a/app/src/main/kotlin/jp/one_system_group/diary_sample_android/infra/di/InfraModule.kt
+++ b/app/src/main/kotlin/jp/one_system_group/diary_sample_android/infra/di/InfraModule.kt
@@ -1,0 +1,23 @@
+package jp.one_system_group.diary_sample_android.infra.di
+
+import android.content.Context
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import jp.one_system_group.diary_sample_android.infra.TokenManager
+import javax.inject.Singleton
+
+@InstallIn(SingletonComponent::class)
+@Module
+class InfraModule {
+
+    @Provides
+    @Singleton
+    fun provideTokenManager(
+        @ApplicationContext context: Context
+    ) = TokenManager(
+        context
+    )
+}

--- a/app/src/main/kotlin/jp/one_system_group/diary_sample_android/model/Auth.kt
+++ b/app/src/main/kotlin/jp/one_system_group/diary_sample_android/model/Auth.kt
@@ -1,0 +1,7 @@
+package jp.one_system_group.diary_sample_android.model
+
+data class Auth(
+    val email: String,
+    val password: String,
+    val deviceId: String
+)

--- a/app/src/main/kotlin/jp/one_system_group/diary_sample_android/repository/AuthRepository.kt
+++ b/app/src/main/kotlin/jp/one_system_group/diary_sample_android/repository/AuthRepository.kt
@@ -1,0 +1,28 @@
+package jp.one_system_group.diary_sample_android.repository
+
+import jp.one_system_group.diary_sample_android.api.WebService
+import jp.one_system_group.diary_sample_android.model.Auth
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+interface AuthRepository {
+    suspend fun login(email: String, password: String, deviceId: String): String?
+}
+
+class AuthRepositoryImpl @Inject constructor(
+    private val webService: WebService,
+) : AuthRepository {
+    override suspend fun login(email: String, password: String, deviceId: String): String? {
+        val response =
+            withContext(Dispatchers.IO) {
+                webService.login(Auth(email, password, deviceId))
+            }
+        return if (response.isSuccessful) {
+            response.body()
+        } else {
+            // TODO: ログイン失敗時の処理
+            null
+        }
+    }
+}

--- a/app/src/main/kotlin/jp/one_system_group/diary_sample_android/repository/di/RepositoryModule.kt
+++ b/app/src/main/kotlin/jp/one_system_group/diary_sample_android/repository/di/RepositoryModule.kt
@@ -7,7 +7,8 @@ import dagger.hilt.components.SingletonComponent
 import jp.one_system_group.diary_sample_android.api.WebService
 import jp.one_system_group.diary_sample_android.database.DiaryContentDao
 import jp.one_system_group.diary_sample_android.database.DiaryDao
-import jp.one_system_group.diary_sample_android.database.di.DatabaseModule_ProvideDaoContentFactory
+import jp.one_system_group.diary_sample_android.repository.AuthRepository
+import jp.one_system_group.diary_sample_android.repository.AuthRepositoryImpl
 import jp.one_system_group.diary_sample_android.repository.DiaryRepository
 import jp.one_system_group.diary_sample_android.repository.DiaryRepositoryImpl
 import javax.inject.Singleton
@@ -15,12 +16,21 @@ import javax.inject.Singleton
 @InstallIn(SingletonComponent::class)
 @Module
 class RepositoryModule {
+
+    @Provides
+    @Singleton
+    fun provideAuthRepository(
+        webService: WebService,
+    ): AuthRepository {
+        return AuthRepositoryImpl(webService)
+    }
+
     @Provides
     @Singleton
     fun provideDiaryRepository(
         webService: WebService,
-        dao : DiaryDao,
-        daoContent : DiaryContentDao
+        dao: DiaryDao,
+        daoContent: DiaryContentDao
     ): DiaryRepository {
         return DiaryRepositoryImpl(webService, dao, daoContent)
     }

--- a/app/src/main/kotlin/jp/one_system_group/diary_sample_android/ui/auth/AuthScreen.kt
+++ b/app/src/main/kotlin/jp/one_system_group/diary_sample_android/ui/auth/AuthScreen.kt
@@ -1,10 +1,12 @@
 package jp.one_system_group.diary_sample_android.ui.auth
 
 import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.navigation.NavHostController
-import androidx.navigation.compose.rememberNavController
 import jp.one_system_group.diary_sample_android.auth.TopLevel
 import jp.one_system_group.diary_sample_android.ui.auth.component.AuthEmail
 import jp.one_system_group.diary_sample_android.ui.auth.component.AuthLogin
@@ -15,7 +17,7 @@ import jp.one_system_group.diary_sample_android.ui.theme.DiarySampleAndroidTheme
 @ExperimentalMaterialApi
 @Composable
 fun AuthScreen(
-    navController: NavHostController,
+    loginProcess: (String, String) -> Unit,
 ) {
     var email by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
@@ -31,9 +33,7 @@ fun AuthScreen(
             onValueChange = { newValue -> password = newValue },
         )
         AuthLogin(
-            onClick = {
-                navController.navigate("main")
-            }
+            onClick = { loginProcess(email, password) },
         )
     }
 }
@@ -43,10 +43,7 @@ fun AuthScreen(
 @Composable
 fun Preview() {
     // Jetpack Composeで表示する用のメソッド
-    val navController = rememberNavController()
     DiarySampleAndroidTheme {
-        AuthScreen(
-            navController
-        )
+        AuthScreen { _, _ -> }
     }
 }

--- a/app/src/main/kotlin/jp/one_system_group/diary_sample_android/ui/home/HomeScreen.kt
+++ b/app/src/main/kotlin/jp/one_system_group/diary_sample_android/ui/home/HomeScreen.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.Flow
 @Composable
 fun HomeScreen(
     navController: NavHostController,
+    loginProcess: (String, String) -> Unit,
     diaryList: Flow<PagingData<DiaryRow>>,
 ) {
 
@@ -23,9 +24,10 @@ fun HomeScreen(
         navController = navController,
         startDestination = "auth"
     ) {
+
         // 認証画面
         composable(route = "auth") {
-            AuthScreen(navController)
+            AuthScreen(loginProcess)
         }
         // 日記一覧画面
         composable(route = "main") {

--- a/app/src/main/kotlin/jp/one_system_group/diary_sample_android/viewmodel/AuthViewModel.kt
+++ b/app/src/main/kotlin/jp/one_system_group/diary_sample_android/viewmodel/AuthViewModel.kt
@@ -1,0 +1,35 @@
+package jp.one_system_group.diary_sample_android.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import jp.one_system_group.diary_sample_android.infra.TokenManager
+import jp.one_system_group.diary_sample_android.repository.AuthRepository
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import java.util.UUID
+import javax.inject.Inject
+
+@HiltViewModel
+class AuthViewModel @Inject constructor(
+    private val repository: AuthRepository,
+    private val tokenManager: TokenManager
+) : ViewModel() {
+
+    private var deviceId: String = UUID.randomUUID().toString()
+    private val _resultFlow = MutableStateFlow<String?>(null)
+    val resultFlow: StateFlow<String?> = _resultFlow
+
+    fun login(email: String, password: String): Job {
+        return viewModelScope.launch {
+            val token = repository.login(email, password, deviceId)
+            if (token != null) {
+                // SharedPreferencesに保存する
+                tokenManager.saveToken(token)
+                _resultFlow.value = token
+            }
+        }
+    }
+}


### PR DESCRIPTION
# 変更内容
認証画面から認証APIを呼び出して認証を行うように修正しました。
認証時に取得したトークンをヘッダに付与してAPI実行するように修正しました。

以下の処理に関してそれぞれライブラリを使用して実現しています。
- トークンの保存
    [SharedPreferences](https://developer.android.com/training/data-storage/shared-preferences?hl=ja)
- トークンをヘッダに付与する
    okhttpの[Interceptor](https://square.github.io/okhttp/features/interceptors/)
- APIのリクエスト内容をログ出力する（デバッグ用です。本番環境では出力しないようにする予定です）
    okhttpの[HttpLoggingInterceptor](https://square.github.io/okhttp/4.x/logging-interceptor/okhttp3.logging/-http-logging-interceptor/)

本修正に伴いバックエンド側の認証APIのほうも修正しています。
https://github.com/1-system-group/Diary-Sample/pull/59

---
以下は未対応です。

- 認証画面はアプリ起動時に毎回表示されます。（認証済みの場合に認証を省略できるようにしていません）
- ログイン後に戻るボタンを押すと認証画面に戻れます
- SharedPreferencesは古いライブラリでこちらの[Jetpack DataStore](https://developer.android.com/topic/libraries/architecture/datastore?hl=ja)使うべきなのですが、していません。
- トークンを暗号化して保存していません